### PR TITLE
Prepend Html Import to Template

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,12 @@ gulp.task("modularize-styles", function() {
             moduleId: function(file) {
                 return path.basename(file.path, path.extname(file.path)) + "-css";
             },
+            // Root Directory (needed to calculate absolute file path)
+            cwd: "./public",
+            // Base Path (Path up until includeFile and Style-Module Path diverge)
+            basePath: "webcomponents",
             // Prepend include to created style-module on this file
-            includeFile: function(file) {
-                return path.basename(file.path, path.extname(file.path)) + ".html";
-            }
+            includeFile: "style-modules.html"
         }))
         .pipe(gulp.dest("./src"));
 }
@@ -58,7 +60,13 @@ gulp.task("modularize-styles", function() {
     // that takes a [vinyl](https://github.com/gulpjs/vinyl) file object and returns a string
     includeFile: function(file) {
         return path.basename(file.path, path.extname(file.path)) + ".html";
-    }
+    },
+    // Root Directory (needed to calculate absolute file path). Can be either a fixed string or a function
+    // that takes a [vinyl](https://github.com/gulpjs/vinyl) file object and returns a string
+    cwd: "./public",
+    // Base Path (Path up until includeFile and Style-Module Path diverge). Can be either a fixed string or a function
+    // that takes a [vinyl](https://github.com/gulpjs/vinyl) file object and returns a string
+    basePath: "webcomponents",
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ gulp.task("modularize-styles", function() {
             // Use '-css' suffix instead of '-styles' for module ids
             moduleId: function(file) {
                 return path.basename(file.path, path.extname(file.path)) + "-css";
+            },
+            // Prepend include to created style-module on this file
+            includeFile: function(file) {
+                return path.basename(file.path, path.extname(file.path)) + ".html";
             }
         }))
         .pipe(gulp.dest("./src"));
@@ -49,6 +53,11 @@ gulp.task("modularize-styles", function() {
     // that takes a [vinyl](https://github.com/gulpjs/vinyl) file object and returns a string
     moduleId: function(file) {
         return path.basename(file.path, path.extname(file.path)) + "-styles";
+    },
+    // string / function to be used for include file path. Can be either a fixed string or a function
+    // that takes a [vinyl](https://github.com/gulpjs/vinyl) file object and returns a string
+    includeFile: function(file) {
+        return path.basename(file.path, path.extname(file.path)) + ".html";
     }
 }
 ```

--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ var through = require('through2');
 var path = require('path');
 var gutil = require('gulp-util');
 var PLUGIN_NAME = 'gulp-style-modules';
+var prependFile = require('prepend-file');
+var fs = require('fs');
 
 module.exports = function(opts) {
     function namefn(file) {
@@ -13,6 +15,7 @@ module.exports = function(opts) {
 
     var fname = opts && opts.filename || namefn;
     var modid = opts && opts.moduleId || namefn;
+    var iFile = opts && opts.includeFile;
 
     return through.obj(function (file, enc, cb) {
 
@@ -25,21 +28,39 @@ module.exports = function(opts) {
 
         var filename = typeof fname === 'function' ? fname(file) : fname;
         var moduleId = typeof modid === 'function' ? modid(file) : modid;
+        var includeFile = typeof iFile === 'function' ? iFile(file) : iFile;
+
         var dirname = path.dirname(file.path);
+        var importStyleModule = '<link rel="import" href="' + filename + '.html' + '">';
 
         var res = '<dom-module id="' + moduleId + '">\n' +
-            '<template>\n' +
-            '<style>\n' +
-            file.contents.toString('utf8') + '\n' +
-            '</style>\n' +
-            '</template>\n' +
-            '</dom-module>';
+          '<template>\n' +
+          '<style>\n' +
+          file.contents.toString('utf8') + '\n' +
+          '</style>\n' +
+          '</template>\n' +
+          '</dom-module>';
 
         file.contents = new Buffer(res);
         file.path = path.join(dirname, filename) + '.html';
+
+        //make sure includeFile argument actually points to an existing file
+        if(includeFile) {
+            fs.exists(includeFile, function(exists) {
+                if (exists) {
+                    //put include into original component
+                    prependFile(includeFile, importStyleModule, function(err) {
+                        if (err) {
+                            // Error
+                            return cb(new gutil.PluginError(PLUGIN_NAME, err));
+                        }
+                        // Success
+                    });
+                }
+            });
+        }
 
         return cb(null, file);
     });
 
 };
-

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ module.exports = function(opts) {
                 //put include into original component
                 var stream = fs.createWriteStream(path.join(sourceDir, basePath, includeFile), {'flags': 'a'});
                 stream.once('open', function(fd) {
-                    stream.write(importStyleModule+"\n");
+                    stream.write("\n"+importStyleModule);
                     stream.end();
                 });
             } else {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "main": "./index.js",
   "dependencies": {
     "gulp-util": "^3.0.6",
-    "prepend-file": "^1.3.0",
     "through2": "^2.0.0"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "main": "./index.js",
   "dependencies": {
     "gulp-util": "^3.0.6",
+    "prepend-file": "^1.3.0",
     "through2": "^2.0.0"
   },
   "license": "MIT",


### PR DESCRIPTION
adds additional possible parameter "includeFile". for each generated style-module, an html import will be prepended to this file.

usage example:
```var stylemodTask = function () {
  return gulp.src(paths.src)
  .pipe(changed(paths.dest)) // Ignore unchanged files
  .pipe(sass(config.tasks.css.sass))
  .on('error', handleErrors)
  .pipe(autoprefixer(config.tasks.css.autoprefixer))
  .pipe(gulpif(global.production, cssnano({autoprefixer: false})))
  .pipe(gulpif(!global.production, sourcemaps.write()))
  .pipe(stylemod({
    filename: function(file) {
      //component name is name of last folder
      var componentName = path.dirname(file.path).split(path.sep).pop()
      return componentName + "-" + path.basename(file.path, path.extname(file.path));
    },
    moduleId: function (file) {
      //component name is name of last folder
      var componentName = path.dirname(file.path).split(path.sep).pop()
      return componentName + "-" + path.basename(file.path, path.extname(file.path));
    },
    includeFile: function (file) {
      //component name is name of last folder
      var componentName = path.dirname(file.path).split(path.sep).pop()
      return `${config.root.dest}/${config.tasks.webcomponents.dest}/${componentName}/template.html`
    }
  }))
  .pipe(gulp.dest(paths.dest))
  .pipe(browserSync.stream())
}